### PR TITLE
Rename some internals for clarity (no functional changes)

### DIFF
--- a/src/Interfaces.jl
+++ b/src/Interfaces.jl
@@ -128,7 +128,7 @@ function toimplements!(IT, arg::Expr, shouldthrow::Bool=true)
             sym = gensym()
             __RT__ = annotation
         end
-        return requiredreturn(T, nm, args, shouldthrow, sym, __RT__)
+        return requiredreturn(IT, nm, args, shouldthrow, sym, __RT__)
     elseif arg.head == :<:
         return :((T <: $IT) || Interfaces.subtypingrequired($IT, T))
     elseif arg.head == :if

--- a/src/Interfaces.jl
+++ b/src/Interfaces.jl
@@ -177,6 +177,8 @@ macro interface(IT, alias_or_block, maybe_block=nothing)
     @assert block isa Expr && block.head == :block
     Base.remove_linenums!(block)
     if IT !== alias
+        # Swap the alias for the InterfaceType itself, so later we can generically swap the
+        # InterfaceType for an arbitrary symbol e.g. :T, regardless of if an alias was used.
         recursiveswapsymbols!(alias, block, IT)
     end
     iface = Interface(IT, deepcopy(block.args))


### PR DESCRIPTION
- Use `IT` for the "InterfaceType" and `T` for the "type that implements the interface"
- rename `recursiveswapT!` -> `recursiveswapsymbols!` now it can swap to any symbol
- add comment about how alis `X` like `@interface Foo X begin; bar(::X); end` is handled
- follow-up to https://github.com/quinnj/Interfaces.jl/pull/14

...hopefully not gonna cause @quinnj terrible merge conflicts... but we can e.g. ditch the T -> IT commit if it does!