### PR TITLE
Test both branches of Tables interface

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,14 +84,14 @@ abstract type AbstractTable end
         if Base.IteratorEltype(RT) == Base.HasEltype()
             eltype(::RT)::Type{Tables.AbstractRow} ||
                 eltype(::Type{RT})::Type{Tables.AbstractRow}
-                
         end
     elseif Tables.columnaccess(AbstractTable)
         Tables.istable(::Type{AbstractTable})
-        Tables.columns(::AbstractTable)::AbstractColumns
+        Tables.columns(::AbstractTable)::Tables.AbstractColumns
     end
 
     # @optional schema(::AbstractTable)::Union{Nothing, Tables.Schema}
 end
 
 @test Interfaces.implements(Tables.DictRowTable, AbstractTable)
+@test Interfaces.implements(Tables.DictColumnTable, AbstractTable)


### PR DESCRIPTION
I was trying out using Interfaces.jl on a package the implements the Tables.jl column table interface, and it turns out the definition in our tests here has a typo ...so this fixes it, and mkes sure we test both branches of the `isrowtable` check.