### PR TITLE
Initial version of a `debug` mode

### DIFF
--- a/src/Interfaces.jl
+++ b/src/Interfaces.jl
@@ -102,7 +102,11 @@ Construct the method signature from a function name and argument types.
 methodsig(f, args) = Expr(:call, f, unconvertargs(args)...)
 
 function requiredmethod(IT, nm, args, shouldthrow)
-    :(Interfaces.implemented($nm, $args, mods) || ($shouldthrow && Interfaces.missingmethod(debuglvl, $IT, $nm, $args, mods)))
+    return quote
+        check = Interfaces.implemented($nm, $args, mods)
+        check || ($shouldthrow && Interfaces.missingmethod(debuglvl, $IT, $nm, $args, mods))
+        check
+    end
 end
 
 function requiredreturn(IT, nm, args, shouldthrow, RT_sym, __RT__)

--- a/src/Interfaces.jl
+++ b/src/Interfaces.jl
@@ -111,12 +111,12 @@ end
 
 function requiredreturn(IT, nm, args, shouldthrow, RT_sym, __RT__)
     return quote
-        $(requiredmethod(IT, nm, args, shouldthrow))
+        check1 = $(requiredmethod(IT, nm, args, shouldthrow))
         $RT_sym = Interfaces.returntype($nm, $args)
         # @show $RT_sym, $nm, $args, Interfaces.isinterfacetype($__RT__)
-        check = Interfaces.isinterfacetype($__RT__) ?  Interfaces.implements($RT_sym, $__RT__) : $RT_sym <: $__RT__
-        check || ($shouldthrow && Interfaces.invalidreturntype(debuglvl, $IT, $nm, $args, $RT_sym, $__RT__))
-        check
+        check2 = Interfaces.isinterfacetype($__RT__) ?  Interfaces.implements($RT_sym, $__RT__) : $RT_sym <: $__RT__
+        check2 || ($shouldthrow && Interfaces.invalidreturntype(debuglvl, $IT, $nm, $args, $RT_sym, $__RT__))
+        check1 & check2
     end
 end
 

--- a/src/Interfaces.jl
+++ b/src/Interfaces.jl
@@ -118,7 +118,7 @@ function requiredreturn(IT, nm, args, shouldthrow, RT_sym, __RT__)
             check &= Interfaces.isinterfacetype($__RT__) ?  Interfaces.implements($RT_sym, $__RT__) : $RT_sym <: $__RT__
             check || ($shouldthrow && Interfaces.invalidreturntype(loglevel, $IT, $nm, $args, $RT_sym, $__RT__))
         end
-        return check
+        check
     end
 end
 


### PR DESCRIPTION
Initial sketch for supporting this. I suspect the code could benefit from some clean up -- comments appreciated!

- users can pass `debug::Bool` to `@implements` or `Interfaces.implements` (default `false`)
- internally we turn this into `debuglvl::Symbol` that's used to determine how exactly things display when `debug=true`

For awhile i tried out having "info" level messages for methods to report succesful steps (`"Required method is defined! ..."`), but personally i found them more noisy than helpful, and also they made the code/logic quite a bit more complex, so i ditched them.

I decided agaiinst using `@warn` etc loggers because (i) i didn't like that they included the module/line info (it's not helpful in this case), (ii) they're quite hard to test in my experience (with `@test_logs`), (iii) I think we can do more interesting things if we have full control over how messages get printed.

also i thought i'd open this up so we can figure out how we want things to look before i go about adding tests!

Example:
<img width="834" alt="Screenshot 2021-11-10 at 17 08 14" src="https://user-images.githubusercontent.com/13448787/141160808-a1e8962e-5d84-4390-84de-6559824c4ba3.png">


