### PR TITLE
Implement show method for Interface type

### DIFF
--- a/src/Interfaces.jl
+++ b/src/Interfaces.jl
@@ -17,7 +17,7 @@ struct Interface
 end
 
 function Base.show(io::IO, ::MIME"text/plain", x::Interface)
-    println(io, "Interface: $(x.name)")
+    print(io, "Interface: $(x.name)")
     foreach(ex -> showexpr(io, ex), x.exprs)
     return
 end
@@ -26,29 +26,29 @@ unwrapblock(ex::Expr) = ex.head == :block ? ex.args[1] : ex
 
 function showexpr(io::IO, arg, indent=1)
     if arg.head == :call
-        println(io, "  "^indent * "* method definition: `$arg`")
+        print(io, "\n" * "  "^indent * "* method definition: `$arg`")
     elseif arg.head == :(::)
-        println(io, "  "^indent * "* method definition with required return type: `$arg`")
+        print(io, "\n" * "  "^indent * "* method definition with required return type: `$arg`")
     elseif arg.head == :<:
-        println(io, "  "^indent * "* subtyping: `T <: $(arg.args[2])`")
+        print(io, "\n" * "  "^indent * "* subtyping: `T <: $(arg.args[2])`")
     elseif arg.head == :if
-        println(io, "  "^indent * "* conditional requirements:")
-        println(io, "  "^(indent + 1) * "* if $(unwrapblock(arg.args[1]))")
+        print(io, "\n" * "  "^indent * "* conditional requirements:")
+        print(io, "\n" * "  "^(indent + 1) * "* if $(unwrapblock(arg.args[1]))")
         showexpr(io, arg.args[2], indent + 2)
         while length(arg.args) > 2
             if arg.args[3].head == :elseif
                 arg = arg.args[3]
-                println(io, "  "^(indent + 1) * "* elseif $(unwrapblock(arg.args[1]))")
+                print(io, "\n" * "  "^(indent + 1) * "* elseif $(unwrapblock(arg.args[1]))")
                 showexpr(io, arg.args[2], indent + 2)
             else
                 # else block
-                println(io, "  "^(indent + 1) * "* else")
+                print(io, "\n" * "  "^(indent + 1) * "* else")
                 showexpr(io, arg.args[3], indent + 2)
                 break
             end
         end
     elseif arg.head == :||
-        println(io, "  "^indent * "* one of the following required:")
+        print(io, "\n" * "  "^indent * "* one of the following required:")
         while true
             showexpr(io, arg.args[1], indent + 1)
             arg.args[2].head == :|| || break
@@ -60,7 +60,7 @@ function showexpr(io::IO, arg, indent=1)
             showexpr(io, x, indent)
         end
     elseif arg.head == :macrocall && arg.args[1] == Symbol("@optional")
-        println(io, "  "^indent * "* optional interface requirement:")
+        print(io, "\n" * "  "^indent * "* optional interface requirement:")
         showexpr(io, arg.args[3], indent + 1)
     end
     return

--- a/src/Interfaces.jl
+++ b/src/Interfaces.jl
@@ -16,7 +16,7 @@ struct Interface
     exprs::Vector{Any}
 end
 
-function Base.show(io::IO, x::Interface)
+function Base.show(io::IO, ::MIME"text/plain", x::Interface)
     println(io, "Interface: $(x.name)")
     foreach(ex -> showexpr(io, ex), x.exprs)
     return

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -130,8 +130,7 @@ abstract type Example end
 
 end
 
-int = Interfaces.interface(Example)
-@test repr(int) == """
+@test repr("text/plain", Interfaces.interface(Example)) == """
 Interface: Example
   * subtyping: `T <: Example`
   * method definition: `foo1(arg::Example, arg2::Int)`
@@ -153,8 +152,7 @@ Interface: Example
         * method definition: `foo13(arg::Example)`
         * method definition: `foo14(arg::Example)`
   * optional interface requirement:
-    * method definition: `foo15(arg::Example)`
-"""
+    * method definition: `foo15(arg::Example)`"""
 
 abstract type AbstractStridedArray end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -131,9 +131,7 @@ abstract type Example end
 end
 
 int = Interfaces.interface(Example)
-io = IOBuffer()
-show(io, int)
-@test String(take!(io)) == """
+@test repr(int) == """
 Interface: Example
   * subtyping: `T <: Example`
   * method definition: `foo1(arg::Example, arg2::Int)`

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -95,3 +95,65 @@ end
 
 @test Interfaces.implements(Tables.DictRowTable, AbstractTable)
 @test Interfaces.implements(Tables.DictColumnTable, AbstractTable)
+
+abstract type Example end
+
+@interface Example T begin
+
+    # required subtyping
+    T <: Example
+
+    # required method definition
+    foo1(arg::Example, arg2::Int)
+
+    # method def w/ return type
+    foo2(arg::Example)::Float64
+
+    # method def w/ interface return type
+    foo3(arg::Example)::Iterable
+
+    # one of many required
+    foo4(arg::Example) || foo5(arg::Example) || foo6(arg::Example)
+
+    # conditional
+    if foo7(T)
+        foo8(arg::Example)
+        foo9(arg::Example)::RT where {RT <: Iterable}
+        foo10(RT)::Int
+    elseif foo11(T)
+        foo12(arg::Example)
+    else
+        foo13(arg::Example) || foo14(arg::Example)
+    end
+
+    @optional foo15(arg::Example)
+
+end
+
+int = Interfaces.interface(Example)
+io = IOBuffer()
+show(io, int)
+@test String(take!(io)) == """
+Interface: Example
+  * subtyping: `T <: Example`
+  * method definition: `foo1(arg::Example, arg2::Int)`
+  * method definition with required return type: `foo2(arg::Example)::Float64`
+  * method definition with required return type: `foo3(arg::Example)::Iterable`
+  * one of the following required:
+    * method definition: `foo4(arg::Example)`
+    * method definition: `foo5(arg::Example)`
+    * method definition: `foo6(arg::Example)`
+  * conditional requirements:
+    * if foo7(Example)
+      * method definition: `foo8(arg::Example)`
+      * method definition with required return type: `foo9(arg::Example)::(RT where RT <: Iterable)`
+      * method definition with required return type: `foo10(RT)::Int`
+    * elseif foo11(Example)
+      * method definition: `foo12(arg::Example)`
+    * else
+      * one of the following required:
+        * method definition: `foo13(arg::Example)`
+        * method definition: `foo14(arg::Example)`
+  * optional interface requirement:
+    * method definition: `foo15(arg::Example)`
+"""


### PR DESCRIPTION
Closes #8. I ended up going with a nested bullet point style, since it
matches very closely how we process interface expressions. Trying to do
a table is still possible, but it was harder to think through how nested
expressions should work and it feels like it gets hairy quickly, whereas
the nested bullet points concisely display the nested levels. There are
certainly enhancements we could do here; maybe give some more verbage
around the return types instead of just printing the expression, and
maybe do something different for the `foo(arg)::RT where {RT <: T}`
case? I think this is a pretty good first pass though.