### PR TITLE
Avoid misleading expression in Example interface

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -119,7 +119,7 @@ abstract type Example end
     if foo7(T)
         foo8(arg::Example)
         foo9(arg::Example)::RT where {RT <: Iterable}
-        foo10(RT)::Int
+        foo10(::RT)::Int
     elseif foo11(T)
         foo12(arg::Example)
     else
@@ -144,7 +144,7 @@ Interface: Example
     * if foo7(Example)
       * method definition: `foo8(arg::Example)`
       * method definition with required return type: `foo9(arg::Example)::(RT where RT <: Iterable)`
-      * method definition with required return type: `foo10(RT)::Int`
+      * method definition with required return type: `foo10(::RT)::Int`
     * elseif foo11(Example)
       * method definition: `foo12(arg::Example)`
     * else


### PR DESCRIPTION
  the current example is perfectly valid,
  but highly confusing, as it uses the variable
  name `RT` which on the previous line is bound
  to the return type, but it's usage on this line
  means it is interpreted as an untyped variable
  i.e. `foo10(RT::Any)` i.e. `foo10(::Any)`
  when we probably meant to write `foo10(::RT)`.
  
  Before this was transformed to (note the `Any`):
  ```jl
                      check = begin
                            check = Interfaces.implemented(foo10, Tuple{Any}, mods)
                            check || true && Interfaces.missingmethod(loglevel, Example, foo10, Tuple{Any}, mods)
                            check
                        end
                    if check
                        var"##283" = Interfaces.returntype(foo10, Tuple{Any})
                        check &= if Interfaces.isinterfacetype(Int)
                                Interfaces.implements(var"##283", Int)
                            else
                                var"##283" <: Int
                            end
                        check || true && Interfaces.invalidreturntype(loglevel, Example, foo10, Tuple{Any}, var"##283", Int)
                    end
  ```
  Now this will have been transfered to (note the `RT`):
  ```jl
                      check = begin
                            check = Interfaces.implemented(foo10, Tuple{RT}, mods)
                            check || true && Interfaces.missingmethod(loglevel, Example, foo10, Tuple{RT}, mods)
                            check
                        end
                    if check
                        var"##286" = Interfaces.returntype(foo10, Tuple{RT})
                        check &= if Interfaces.isinterfacetype(Int)
                                Interfaces.implements(var"##286", Int)
                            else
                                var"##286" <: Int
                            end
                        check || true && Interfaces.invalidreturntype(loglevel, Example, foo10, Tuple{RT}, var"##286", Int)
                    end
  ```
  ---
  
 More interesting is than changing some test code, which in practice is of no consequence (except insofar as it is an example), is this looks to me like a very easy mistake to make! 
 
 And it makes me wonder how we can better protect users against such a mistake?
  
One thing that came to mind, now we have pretty-printing, is we could add `::Any` type annotations to untyped arguments in the output 

i.e. the `show` before had:
```jl
      * method definition with required return type: `foo9(arg::Example)::(RT where RT <: Iterable)`
      * method definition with required return type: `foo10(RT)::Int`
```
But we could change `show` to print instead:
```jl
      * method definition with required return type: `foo9(arg::Example)::(RT where RT <: Iterable)`
      * method definition with required return type: `foo10(RT::Any)::Int`
```
which would at least _visually_ give a clearer impression of what is going on (and hopefully make the mistake easier to spot)

But I'm not sure if/how we could do a more automatic safety check against this kind of mistake 