### PR TITLE
Initial idea for generating a test function for an interface

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,22 @@ abstract type Iterable end
         eltype(::Iterable) || eltype(::Type{Iterable})
     end
 
+    @test x begin
+        i = 0
+        state = iterate(x)
+        eT = Base.IteratorEltype(x) == Base.HasEltype() ? eltype(x) : Any
+        while state !== nothing
+            val, st = state
+            @test val isa eT
+            i += 1
+            state = iterate(x, st)
+        end
+        if Base.IteratorSize(x) == Base.HasLength()
+            @test i == length(x)
+        elseif Base.IteratorSize(x) == Base.HasShape()
+            @test i == length(x)
+        end
+    end
 end
 
 @test Interfaces.implements(Int, Iterable, [Base])


### PR DESCRIPTION
The idea here is that we could provide an
`Interfaces.testinterface(::Type{IT}, x)` function that implementors
could put in their test suite like
`Interfaces.testinterface(AbstractTable, MyTable())`, so they specify
the interface they're testing against, and an _instance_ of their
implementing type. In the `@interface` definition, a `@test begin ...
end` block can be provided that, at a minimum, takes an instance
variable name like `x` and checks whatever necessary for the interface.

I think we'll need to allow passing in other variables as well, like for
the `setindex!` case for `AbstractArray`.